### PR TITLE
Add portfolio pages with dynamic work routes and metadata

### DIFF
--- a/src/data/works.json
+++ b/src/data/works.json
@@ -1,0 +1,18 @@
+[
+  {
+    "slug": "project-one",
+    "title": "Project One",
+    "subtitle": "An amazing first project",
+    "image": "https://via.placeholder.com/800x450",
+    "description": "Case study for Project One",
+    "body": "Detailed information about Project One."
+  },
+  {
+    "slug": "project-two",
+    "title": "Project Two",
+    "subtitle": "Another fantastic project",
+    "image": "https://via.placeholder.com/800x450",
+    "description": "Case study for Project Two",
+    "body": "Detailed information about Project Two."
+  }
+]

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,8 @@ import "../styles/global.css";
 import Nav from "../components/Nav.astro";
 import FooterClock from "../components/FooterClock.astro";
 import reveal from "../components/reveal.js";
+
+const { title = "Astro Basics", description } = Astro.props;
 ---
 <!doctype html>
 <html lang="en">
@@ -11,7 +13,8 @@ import reveal from "../components/reveal.js";
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <title>Astro Basics</title>
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
   </head>
   <body class="min-h-screen bg-white text-neutral-900">
     <a href="#main" class="sr-only focus:not-sr-only">Skip to content</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,10 @@
+---
+import Base from '../layouts/Base.astro';
+import SectionIntro from '../components/SectionIntro.astro';
+---
+<Base title="About" description="Learn more about me">
+  <SectionIntro title="About" intro="Who I am" />
+  <div class="prose mx-auto max-w-3xl py-8">
+    <p>This is a brief description about the portfolio owner.</p>
+  </div>
+</Base>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,8 @@
+---
+import Base from '../layouts/Base.astro';
+---
+<Base title="Contact" description="Get in touch">
+  <div class="flex min-h-[60vh] items-center justify-center">
+    <a href="mailto:hello@example.com" class="rounded bg-blue-600 px-8 py-4 text-white">Email me</a>
+  </div>
+</Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,22 +4,22 @@ import Hero from '../components/Hero.astro';
 import SectionIntro from '../components/SectionIntro.astro';
 import FeatureList from '../components/FeatureList.astro';
 import WorkGrid from '../components/WorkGrid.astro';
+import works from '../data/works.json';
 
 const features = [
   { title: 'Fast', text: 'Astro loads fast.' },
   { title: 'Modern', text: 'Built with the modern web.' },
   { title: 'Flexible', text: 'Fits any stack.' }
 ];
-
-const work = [
-  { title: 'Project One', image: 'https://via.placeholder.com/400x300', href: '#' },
-  { title: 'Project Two', image: 'https://via.placeholder.com/400x300', href: '#' },
-  { title: 'Project Three', image: 'https://via.placeholder.com/400x300', href: '#' }
-];
+const work = works.map((w) => ({
+  title: w.title,
+  image: w.image,
+  href: `/work/${w.slug}/`
+}));
 
 ---
 
-<Base>
+<Base title="Home" description="Welcome to my portfolio">
   <Hero />
   <SectionIntro title="Features" intro="Why this portfolio rocks" />
   <FeatureList features={features} />

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -1,0 +1,23 @@
+---
+import Base from '../../layouts/Base.astro';
+import CaseHeader from '../../components/CaseHeader.astro';
+import works from '../../data/works.json';
+
+export async function getStaticPaths() {
+  return works.map((work) => ({ params: { slug: work.slug } }));
+}
+
+const { slug } = Astro.params;
+const work = works.find((w) => w.slug === slug);
+
+if (!work) {
+  throw new Error(`Work not found: ${slug}`);
+}
+---
+<Base title={work.title} description={work.description}>
+  <CaseHeader title={work.title} subtitle={work.subtitle} />
+  <img src={work.image} alt={work.title} class="aspect-[16/9] w-full object-cover" />
+  <div class="prose mx-auto max-w-3xl py-8">
+    <p>{work.body}</p>
+  </div>
+</Base>

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -1,0 +1,14 @@
+---
+import Base from '../../layouts/Base.astro';
+import WorkGrid from '../../components/WorkGrid.astro';
+import works from '../../data/works.json';
+
+const items = works.map((work) => ({
+  title: work.title,
+  image: work.image,
+  href: `/work/${work.slug}/`
+}));
+---
+<Base title="Work" description="A selection of my projects">
+  <WorkGrid items={items} />
+</Base>


### PR DESCRIPTION
## Summary
- add `works.json` and dynamic work detail page with static paths
- implement `about`, `work`, and `contact` pages using shared layout
- make `Base` layout accept per-page title/description and wire up home and work index pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689888ad4bf08325ac57d03977fcbd14