### PR TITLE
feat: add gsap reveal animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "my-portfolio",
       "version": "0.0.1",
       "dependencies": {
-        "astro": "^5.12.3"
+        "astro": "^5.12.3",
+        "gsap": "^3.13.0"
       },
       "devDependencies": {
         "@astrojs/tailwind": "^6.0.2",
@@ -2596,6 +2597,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/gsap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.13.0.tgz",
+      "integrity": "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/h3": {
       "version": "1.15.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^5.12.3"
+    "astro": "^5.12.3",
+    "gsap": "^3.13.0"
   },
   "devDependencies": {
     "@astrojs/tailwind": "^6.0.2",

--- a/public/reveal-init.js
+++ b/public/reveal-init.js
@@ -1,0 +1,3 @@
+import reveal from '/src/components/reveal.js';
+
+document.addEventListener('DOMContentLoaded', reveal);

--- a/src/components/CaseHeader.astro
+++ b/src/components/CaseHeader.astro
@@ -1,7 +1,7 @@
 ---
 const { title, subtitle } = Astro.props;
 ---
-<header class="bg-gray-100 py-16 text-center" data-reveal>
-  <h1 class="mb-2 text-3xl font-bold">{title}</h1>
+<header class="bg-gray-100 py-16 text-center">
+  <h1 data-reveal class="mb-2 text-3xl font-bold">{title}</h1>
   {subtitle && <p class="text-lg text-gray-600">{subtitle}</p>}
 </header>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,8 +1,8 @@
 ---
 ---
 <section class="grid place-items-center py-24 text-center" id="about">
-  <div data-reveal class="max-w-2xl">
-    <h1 class="mb-4 text-4xl font-bold">Hi, I'm Astro</h1>
-    <p class="text-lg text-gray-600">A minimal portfolio starter.</p>
+  <div class="max-w-2xl">
+    <h1 data-reveal class="mb-4 text-4xl font-bold">Hi, I'm Astro</h1>
+    <p data-reveal class="text-lg text-gray-600">A minimal portfolio starter.</p>
   </div>
 </section>

--- a/src/components/SectionIntro.astro
+++ b/src/components/SectionIntro.astro
@@ -1,7 +1,7 @@
 ---
 const { title, intro } = Astro.props;
 ---
-<section class="mx-auto max-w-2xl py-12 text-center" data-reveal>
-  <h2 class="mb-2 text-2xl font-semibold">{title}</h2>
+<section class="mx-auto max-w-2xl py-12 text-center">
+  <h2 data-reveal class="mb-2 text-2xl font-semibold">{title}</h2>
   <p class="text-gray-600">{intro}</p>
 </section>

--- a/src/components/reveal.js
+++ b/src/components/reveal.js
@@ -1,18 +1,24 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('opacity-100', 'translate-y-0');
-        entry.target.classList.remove('opacity-0', 'translate-y-4');
-        observer.unobserve(entry.target);
-      }
-    });
-  }, {
-    threshold: 0.1
-  });
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
-  document.querySelectorAll('[data-reveal]').forEach((el) => {
-    el.classList.add('opacity-0', 'translate-y-4', 'transition', 'duration-700');
-    observer.observe(el);
+export default function reveal() {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+  gsap.registerPlugin(ScrollTrigger);
+
+  ScrollTrigger.batch('[data-reveal]', {
+    start: 'top 85%',
+    onEnter: (batch) =>
+      gsap.fromTo(
+        batch,
+        { opacity: 0, y: 12 },
+        {
+          opacity: 1,
+          y: 0,
+          duration: 0.6,
+          ease: 'power2.out',
+          stagger: 0.08,
+        }
+      ),
   });
-});
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,8 +2,6 @@
 import "../styles/global.css";
 import Nav from "../components/Nav.astro";
 import FooterClock from "../components/FooterClock.astro";
-import reveal from "../components/reveal.js";
-
 const { title = "Astro Basics", description } = Astro.props;
 ---
 <!doctype html>
@@ -23,7 +21,7 @@ const { title = "Astro Basics", description } = Astro.props;
       <slot />
     </main>
     <FooterClock />
-    <script is:inline>{reveal}</script>
+    <script type="module" src="/reveal-init.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add GSAP + ScrollTrigger reveal animations
- trigger reveal on DOMContentLoaded via public script
- annotate hero, headings, and cards with `data-reveal`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68988c4860988325af78d906b2cd799f