### PR TITLE
Add SEO meta tags and page metadata

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,7 +2,7 @@
 import "../styles/global.css";
 import Nav from "../components/Nav.astro";
 import FooterClock from "../components/FooterClock.astro";
-const { title = "Astro Basics", description } = Astro.props;
+const { title = "Astro Basics", description, image } = Astro.props;
 ---
 <!doctype html>
 <html lang="en">
@@ -13,6 +13,13 @@ const { title = "Astro Basics", description } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
+    <meta property="og:title" content={title} />
+    {description && <meta property="og:description" content={description} />}
+    {image && <meta property="og:image" content={image} />}
+    <meta name="twitter:title" content={title} />
+    {description && <meta name="twitter:description" content={description} />}
+    {image && <meta name="twitter:image" content={image} />}
+    <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
   </head>
   <body class="min-h-screen bg-white text-neutral-900">
     <a href="#main" class="sr-only focus:not-sr-only">Skip to content</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,11 @@
 ---
 import Base from '../layouts/Base.astro';
 import SectionIntro from '../components/SectionIntro.astro';
+
+const title = 'About';
+const description = 'Learn more about me';
 ---
-<Base title="About" description="Learn more about me">
+<Base {title} {description}>
   <SectionIntro title="About" intro="Who I am" />
   <div class="prose mx-auto max-w-3xl py-8">
     <p>This is a brief description about the portfolio owner.</p>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,7 +1,10 @@
 ---
 import Base from '../layouts/Base.astro';
+
+const title = 'Contact';
+const description = 'Get in touch';
 ---
-<Base title="Contact" description="Get in touch">
+<Base {title} {description}>
   <div class="flex min-h-[60vh] items-center justify-center">
     <a href="mailto:hello@example.com" class="rounded bg-blue-600 px-8 py-4 text-white">Email me</a>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,9 @@ import FeatureList from '../components/FeatureList.astro';
 import WorkGrid from '../components/WorkGrid.astro';
 import works from '../data/works.json';
 
+const title = 'Home';
+const description = 'Welcome to my portfolio';
+
 const features = [
   { title: 'Fast', text: 'Astro loads fast.' },
   { title: 'Modern', text: 'Built with the modern web.' },
@@ -19,7 +22,7 @@ const work = works.map((w) => ({
 
 ---
 
-<Base title="Home" description="Welcome to my portfolio">
+<Base {title} {description}>
   <Hero />
   <SectionIntro title="Features" intro="Why this portfolio rocks" />
   <FeatureList features={features} />

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -13,8 +13,13 @@ const work = works.find((w) => w.slug === slug);
 if (!work) {
   throw new Error(`Work not found: ${slug}`);
 }
+
+const title = work.title;
+const description =
+  work.excerpt.length > 160 ? `${work.excerpt.slice(0, 157)}...` : work.excerpt;
+const image = work.thumbnail;
 ---
-<Base title={work.title} description={work.excerpt}>
+<Base {title} {description} image={image}>
   <CaseHeader title={work.title} subtitle={`${work.year} • ${work.role}`} />
   <img src={work.thumbnail} alt={work.title} class="aspect-[3/2] w-full object-cover" />
   <div class="prose mx-auto max-w-3xl py-8">

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -3,12 +3,15 @@ import Base from '../../layouts/Base.astro';
 import WorkGrid from '../../components/WorkGrid.astro';
 import works from '../../data/works.json';
 
+const title = 'Work';
+const description = 'A selection of my projects';
+
 const items = works.map((work) => ({
   title: work.title,
   thumbnail: work.thumbnail,
   href: `/work/${work.slug}/`
 }));
 ---
-<Base title="Work" description="A selection of my projects">
+<Base {title} {description}>
   <WorkGrid items={items} />
 </Base>


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter meta tags to Base layout
- define title and description per page and pass them through layout props
- use work thumbnails for og:image and shorten excerpts for descriptions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68988e7d847883258eb78de2aad4b2c2